### PR TITLE
specifiy which pywrap required to build from src

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The easiest way to get started is to use conda:
 ```
 conda install -c conda-forge -c cadquery ocp
 ```
-Building from sources is also possible,
+Building from sources is also possible using https://github.com/CadQuery/pywrap
 ```
 pywrap all ocp.toml
 cmake -S OCP -B build


### PR DESCRIPTION
I spent a while scratching my head wondering why `pywrap` wouldn't work before realising I should be using the version of pywrap in the cadquery org.

This PR is a simple addition to the README to point readers towards github.com/CadQuery/pywrap